### PR TITLE
📝[JSCONF US]Updated JSCONF US to show Tickets on sale and Open CFP

### DIFF
--- a/conferences/jsconf.yaml
+++ b/conferences/jsconf.yaml
@@ -41,7 +41,7 @@
     site: https://2019.jsconf.us
     logo: https://2015.jsconf.us/img/js-sized.png
     location: Carlsbad, California
-    status: opencfp
+    status: opencfp onsale
 
 # JSConf AU
 - jsconfau:
@@ -91,9 +91,7 @@
     name: JSConf Budapest
     site: http://jsconfbp.com
     logo: images/jsconf_bp.png
-    status: 
-     - onsale
-     - opencfp
+    status: onsale opencfp
 
 # JSConf Belgium
 - jsconfbelgium:


### PR DESCRIPTION
![screen shot 2019-02-07 at 3 56 15 pm](https://user-images.githubusercontent.com/5985850/52442602-96fa9400-2af1-11e9-8225-9ff9a95654ff.png)
* Array value of both `opencfp` and `onsale` doesn't work.  Changed value for JSCONF US to onsale and opencfp to provide status for both onsale and opencfp.  Screenshot shows what changed value represents.

* Fixed JSCONF Budapest array to append status to show the same as indicated in their PR in last commit.  

@cramforce 