### PR TITLE
Deleted onsale from JSCONFUS in yaml

### DIFF
--- a/conferences/jsconf.yaml
+++ b/conferences/jsconf.yaml
@@ -33,7 +33,6 @@
     site: https://2019.jsconf.us
     logo: https://2015.jsconf.us/img/js-sized.png
     location: Carlsbad, California
-    status: onsale
 
 # JSConf Budapest
 - jsconfbudapest:


### PR DESCRIPTION
- Deleted onsale from `conferences/jsconf.yaml`