### PR TITLE
 Update jsconf.yaml to close jsconf india cfp

### DIFF
--- a/conferences/jsconf.yaml
+++ b/conferences/jsconf.yaml
@@ -34,7 +34,7 @@
     site: https://jsconf.in
     logo: https://www.jsconf.in/JSConfIN.png
     location: Bengaluru, India
-    status: opencfp onsale
+    status: onsale
 
 # JSConf México
 - jsconfmx:


### PR DESCRIPTION
Jsconf India's 2023 edition's full speaker list is now announced on the website. This change disables CFP status. Tickets are still available. -- https://jsconf.in/