### PR TITLE
Update: jsconf.yaml to remove the link to the js conf Uruguay

### DIFF
--- a/conferences/jsconf.yaml
+++ b/conferences/jsconf.yaml
@@ -118,12 +118,6 @@
     site: http://jsconf.is
     logo: images/jsconf_is.png
 
-# JSConf UY
-- jsconfuy:
-    name: JSConf UY
-    site: http://jsconf.uy
-    logo: images/jsconf_uy.png
-
 # JSConf Belgium
 - jsconfbelgium:
     name: JSConf Belgium


### PR DESCRIPTION
For years, the JSConf Uruguay has not been held anymore. 

When the domain expired, someone purchased it and set up a blog to capitalize on the existing traffic. Therefore, I am submitting a pull request to remove the link from the official JSConf page.

In Uruguay, we have discussed the possibility of organizing a JSConf in the future.